### PR TITLE
Windows builds of tensorflow can have problems with reading from s3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - pykalman=0.9
   - python=3
   - requests=2
+  - s3fs
   - tensorflow=1.13
   - tqdm=4


### PR DESCRIPTION
In that case, cache s3 artifacts directly on the user's machine before
proceeding.

@vahedi25411 Can you check to see if this fixes your s3 issue from https://github.com/CityOfLosAngeles/automated-walk-bike-counter/issues/35#issuecomment-568078688 ?