### PR TITLE
Always use s3fs

### DIFF
--- a/automated_walk_bike_counter/core/configuration.py
+++ b/automated_walk_bike_counter/core/configuration.py
@@ -134,16 +134,6 @@ parser.add_argument(
     env_var="VALID_OBJECTS",
 )
 
-# Storage backend settings
-parser.add_argument(
-    "--AWS_REGION",
-    help="AWS region for when the weights are stored in S3",
-    required=False,
-    type=str,
-    default="us-west-1",
-    env_var="AWS_REGION",
-)
-
 parser.add_argument(
     "--anchor_path",
     type=str,

--- a/automated_walk_bike_counter/core/tracking/object_tracker.py
+++ b/automated_walk_bike_counter/core/tracking/object_tracker.py
@@ -18,7 +18,6 @@ from urllib.parse import urlparse
 
 import cv2
 import numpy as np
-import s3fs
 import tensorflow as tf
 from munkres import Munkres
 
@@ -448,24 +447,28 @@ class ObjectTracker:
             # TODO: figure out a more robust way of handling this, so
             # that we can have multiple regions or different storage backends.
             restore_path = args.restore_path
-            os.environ["AWS_REGION"] = config.AWS_REGION
-            if urlparse(restore_path).scheme == "s3" and sys.platform == "win32":
-                print("Windows detected -- caching s3 artifacts")
-                fs = s3fs.S3FileSystem(anon=True)
-                dirname = os.path.dirname(restore_path)
-                objects = fs.ls(dirname)[1:]  # The first entry is the directory itself
-                cache = os.path.join(os.path.expanduser("~"), ".awbc")
-                if not os.path.exists(cache):
-                    os.mkdir(cache)
-                for obj in objects:
-                    print(f"Copying {obj}")
-                    out = os.path.join(cache, os.path.basename(obj))
-                    if not os.path.exists(out):
-                        with fs.open(obj, "rb") as ifile:
-                            with open(out, "wb") as ofile:
-                                ofile.write(ifile.read())
-                restore_path = os.path.join(cache, os.path.basename(restore_path))
-                print("Restoring from cache: ", restore_path)
+            scheme = urlparse(restore_path).scheme
+            if scheme:
+                import fsspec
+                from fsspec.implementations.cached import WholeFileCacheFileSystem
+
+                kwargs = {"anon": True} if scheme == "s3" or scheme == "gcs" else {}
+                path = fsspec.core.strip_protocol(restore_path)
+                basename = os.path.basename(path)
+                dirname = os.path.dirname(path)
+                target = fsspec.filesystem(scheme, **kwargs)
+                cache_dir = "/tmp/awbc/"
+                fs = WholeFileCacheFileSystem(
+                    fs=target, cache_storage=cache_dir, same_names=True,
+                )
+                # Get the object list, filtering out the directory itself.
+                objects = [o for o in fs.ls(dirname) if o.rstrip("/") != dirname]
+                # Trigger caching of the objects
+                for o in objects:
+                    print(f"Caching {o}")
+                    fs.open(o)
+                # Set the restore path to be the cached index
+                restore_path = os.path.join(cache_dir, basename)
 
             saver = tf.train.Saver()
             saver.restore(sess, restore_path)

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - configargparse=0.14
-  - fsspec=0.7.2
+  - fsspec=0.7.3
   - libtiff=4.0
   - munkres=1
   - opencv=4
@@ -12,6 +12,6 @@ dependencies:
   - pykalman=0.9
   - python=3
   - requests=2
-  - s3fs
+  - s3fs=0.3.5
   - tensorflow=1.13
   - tqdm=4

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - configargparse=0.14
-  - fsspec=0.5
+  - fsspec=0.7.2
   - libtiff=4.0
   - munkres=1
   - opencv=4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ munkres
 pykalman
 pillow
 tqdm
-fsspec>=0.7.2
+fsspec>=0.7.3
 requests
 configargparse
+s3fs==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ munkres
 pykalman
 pillow
 tqdm
-fsspec
+fsspec>=0.7.2
 requests
 configargparse


### PR DESCRIPTION
This reworks the model weight caching to always use fsspec/s3fs for remote weights. The tensorflow s3 reader was pretty unreliable, and I have found this to be a better system. It should also generalize better to other storage models if we should want to use them.